### PR TITLE
Updates to AI Recruitment Limits

### DIFF
--- a/.vscode/ca_types.lua
+++ b/.vscode/ca_types.lua
@@ -8,6 +8,7 @@
 --# assume global class CA_Component
 --# assume global class CA_UIContext
 --# assume global class CA_CHAR_CONTEXT
+--# assume global class CA_UNIT_CONTEXT
 --# assume global class CA_SETTLEMENT_CONTEXT
 --# assume global class CA_CQI
 --# assume global class CA_CHAR
@@ -69,6 +70,7 @@
 --# assume CA_UIContext.string: string
 --# assume CA_SETTLEMENT_CONTEXT.garrison_residence: method() --> CA_GARRISON_RESIDENCE
 --# assume CA_CHAR_CONTEXT.character: method() --> CA_CHAR
+--# assume CA_UNIT_CONTEXT.unit: method() --> CA_UNIT
 
 -- UIC
 --# assume CA_UIC.Address: method() --> CA_Component

--- a/script/campaign/mod/AICharacterRecruitmentControls.lua
+++ b/script/campaign/mod/AICharacterRecruitmentControls.lua
@@ -118,7 +118,7 @@ local function limit_character(character, groupID, difference)
         end
     end
 end
-    
+
 --v function(character: CA_CHAR, recruited_unit: CA_UNIT)
 local function rm_ai_recruitment(character, recruited_unit)
     local rec_char = rm:get_character_by_cqi(character:command_queue_index())
@@ -146,8 +146,6 @@ local function rm_ai_recruitment(character, recruited_unit)
                     local force = character:military_force()
                     local force_cqi = force:command_queue_index()
 
-                    -- get the force's value pre-removal
-                    local prior_value = cm:force_gold_value(force_cqi)
                     -- remove it
                     cm:remove_unit_from_character(cm:char_lookup_str(cqi), unit_to_remove_key)
                     rm:log("removed recruited unit ["..unit_to_remove_key.."] costing ["..rm:get_weight_for_unit(unit_to_remove_key, rm:get_character_by_cqi(cqi)).."] points!")
@@ -179,8 +177,8 @@ local function rm_ai_recruitment(character, recruited_unit)
                             end,
                             function(context)
                                 local unit_cost = context:unit():get_unit_custom_battle_cost()
-                                cm:treasury_mod(character:faction():name(), unit_cost)
-                                rm:log("charged ["..context:unit():get_unit_custom_battle_cost().."]g for replacement unit ["..context:unit():unit_key().."]")
+                                cm:treasury_mod(character:faction():name(), -unit_cost)
+                                rm:log("charged ["..unit_cost.."]g for replacement unit ["..context:unit():unit_key().."]")
                             end,
                             false)
                         core:add_listener(
@@ -195,10 +193,10 @@ local function rm_ai_recruitment(character, recruited_unit)
                             end,
                             false)
                     end
-                    -- refund reasury the lost gold value of the force
-                    local refund = prior_value - cm:force_gold_value(force_cqi)
+                    -- refund treasury the gold value of the the removed unit
+                    local refund = recruited_unit:get_unit_custom_battle_cost()
                     cm:treasury_mod(character:faction():name(), refund)
-                    rm:log("refunded ["..refund.."]g for lost value (["..prior_value.."] - ["..cm:force_gold_value(force_cqi).."])")
+                    rm:log("refunded ["..refund.."]g for lost value")
 
                     break
                 end

--- a/script/campaign/mod/AICharacterRecruitmentControls.lua
+++ b/script/campaign/mod/AICharacterRecruitmentControls.lua
@@ -147,17 +147,6 @@ local function rm_ai_recruitment(character, recruited_unit)
                                 rm:log("charged ["..unit_cost.."]g for replacement unit ["..context:unit():unit_key().."]")
                             end,
                             false)
-                        core:add_listener(
-                            "rm_granted_unit_to_ai_force_gc",
-                            "FactionTurnEnd",
-                            function(context)
-                                return context:faction():name() == character_faction
-                            end,
-                            function(context)
-                                rm:log("ending listening for unit creation for ["..context:faction():name().."]")
-                                core:remove_listener("rm_granted_unit_to_ai_force")
-                            end,
-                            false)
                     end
                     break
                 end

--- a/script/campaign/mod/AICharacterRecruitmentControls.lua
+++ b/script/campaign/mod/AICharacterRecruitmentControls.lua
@@ -7,15 +7,15 @@ local subculture_defaults = {
     ["wh_main_sc_brt_bretonnia"] = {"wh_main_brt_cav_knights_of_the_realm", "wh_dlc07_brt_inf_men_at_arms_2", "wh_main_brt_inf_peasant_bowmen", "wh_main_brt_cav_knights_of_the_realm"},
     ["wh_main_sc_chs_chaos"] = {"wh_main_chs_inf_chaos_warriors_0", "wh_main_chs_cav_chaos_chariot", "wh_main_chs_inf_chaos_warriors_0", "wh_main_chs_inf_chaos_warriors_0", "wh_dlc01_chs_inf_forsaken_0"},
     ["wh_main_sc_grn_greenskins"] = {"wh_main_grn_inf_orc_big_uns", "wh_dlc06_grn_inf_nasty_skulkers_0", "wh_main_grn_inf_orc_arrer_boyz"},
-    ["wh_main_sc_grn_savage_orcs"] = {"wh_main_grn_inf_savage_orc_big_uns","wh_main_grn_inf_savage_orc_arrer_boyz"},
+    ["wh_main_sc_grn_savage_orcs"] = {"wh_main_grn_inf_savage_orc_big_uns", "wh_main_grn_inf_savage_orc_arrer_boyz"},
     ["wh_main_sc_nor_norsca"] = {"wh_main_nor_inf_chaos_marauders_0", "wh_dlc08_nor_inf_marauder_hunters_1", "wh_main_nor_inf_chaos_marauders_0", "wh_dlc08_nor_inf_marauder_spearman_0", "wh_main_nor_cav_marauder_horsemen_0"},
-    ["wh_main_sc_vmp_vampire_counts"] = {"wh_main_vmp_inf_crypt_ghouls"}, 
+    ["wh_main_sc_vmp_vampire_counts"] = {"wh_main_vmp_inf_crypt_ghouls", "wh_main_vmp_inf_skeleton_warriors_0", "wh_main_vmp_inf_skeleton_warriors_1", "wh_main_vmp_inf_zombie"}, 
     ["wh2_dlc09_sc_tmb_tomb_kings"] = {"wh2_dlc09_tmb_inf_nehekhara_warriors_0", "wh2_dlc09_tmb_inf_skeleton_archers_0", "wh2_dlc09_tmb_veh_skeleton_archer_chariot_0", "wh2_dlc09_tmb_inf_nehekhara_warriors_0"},
-    ["wh2_main_sc_def_dark_elves"] = {"wh2_main_def_inf_black_ark_corsairs_0","wh2_main_def_inf_darkshards_0", "wh2_main_def_inf_dreadspears_0"},
-    ["wh2_main_sc_hef_high_elves"] = {"wh2_main_hef_inf_spearmen_0", "wh2_main_hef_inf_spearmen_0", "wh2_main_hef_inf_archers_1", "wh2_main_hef_cav_silver_helms_0", "wh2_main_hef_inf_lothern_sea_guard_1"},
-    ["wh2_main_sc_lzd_lizardmen"] = {"wh2_main_lzd_inf_saurus_warriors_1", "wh2_main_lzd_inf_saurus_spearmen_0", "wh2_main_lzd_inf_saurus_warriors_1", "wh2_main_lzd_inf_skink_cohort_1"},
+    ["wh2_main_sc_def_dark_elves"] = {"wh2_main_def_inf_black_ark_corsairs_0","wh2_main_def_inf_darkshards_0", "wh2_main_def_inf_dreadspears_0","wh2_main_def_inf_darkshards_1", "wh2_main_def_inf_bleakswords_0"},
+    ["wh2_main_sc_hef_high_elves"] = {"wh2_main_hef_inf_spearmen_0", "wh2_main_hef_inf_archers_0", "wh2_main_hef_inf_archers_1", "wh2_main_hef_cav_silver_helms_0", "wh2_main_hef_inf_lothern_sea_guard_1"},
+    ["wh2_main_sc_lzd_lizardmen"] = {"wh2_main_lzd_inf_saurus_warriors_0", "wh2_main_lzd_inf_saurus_spearmen_0", "wh2_main_lzd_inf_saurus_warriors_1", "wh2_main_lzd_inf_skink_cohort_1"},
     ["wh2_main_sc_skv_skaven"]  = {"wh2_main_skv_inf_clanrats_1", "wh2_main_skv_inf_clanrat_spearmen_1", "wh2_main_skv_inf_night_runners_1"},
-    ["wh2_dlc11_sc_cst_vampire_coast"] = {"wh2_dlc11_cst_inf_zombie_gunnery_mob_0", "wh2_dlc11_cst_inf_zombie_gunnery_mob_0", "wh2_dlc11_cst_inf_zombie_gunnery_mob_1", "wh2_dlc11_cst_mon_bloated_corpse_0", "wh2_dlc11_cst_inf_zombie_deckhands_mob_1"}
+    ["wh2_dlc11_sc_cst_vampire_coast"] = {"wh2_dlc11_cst_inf_zombie_deckhands_mob_0", "wh2_dlc11_cst_inf_zombie_gunnery_mob_0", "wh2_dlc11_cst_inf_zombie_gunnery_mob_1", "wh2_dlc11_cst_inf_zombie_deckhands_mob_1"}
 } --:map<string, vector<string>>
 
 for subculture, unit_vector in pairs(subculture_defaults) do

--- a/script/campaign/mod/AICharacterRecruitmentControls.lua
+++ b/script/campaign/mod/AICharacterRecruitmentControls.lua
@@ -49,31 +49,73 @@ local function limit_character(character, groupID, difference)
     end
     local diff = difference
     local cqi = character:command_queue_index()
+    local force = character:military_force()
+    local force_cqi = force:command_queue_index()
 
     rm:log("limiting character ["..tostring(cqi).."] in group ["..groupID.."] who has a difference of ["..diff.."] ")
-    local unit_list = character:military_force():unit_list()
+
+    while diff > 0 do
+        -- find all units in force belonging to group
+        local unit_list = force:unit_list()
+        local units_to_remove = {}
     for j = 0, unit_list:num_items() - 1 do
-        local unit = unit_list:item_at(j):unit_key()
-        local groups_list = rm:get_unit(unit):groups()
-        for c_groupID, _ in pairs(groups_list) do
-            if c_groupID == groupID then
-                for l = 0, character:military_force():unit_list():num_items() - 1 do
-                    local unit_obj = character:military_force():unit_list():item_at(l)
-                    if unit_obj:unit_key() == unit then
-                        cm:treasury_mod(unit_obj:faction():name(), unit_obj:get_unit_custom_battle_cost())
+            local unit = unit_list:item_at(j)
+            local groups_list = rm:get_unit(unit:unit_key()):groups()
+            for group_key, _ in pairs(groups_list) do
+                if group_key == groupID then
+                    table.insert(units_to_remove,unit)
+                    break
                     end
                 end
-                cm:remove_unit_from_character(cm:char_lookup_str(cqi), unit)
+        end
+        -- pick one at random
+        local unit_to_remove = units_to_remove[cm:random_number(#units_to_remove)]
+        local unit_to_remove_key = unit_to_remove:unit_key()
+        local pt_value = rm:get_weight_for_unit(unit_to_remove_key, rm:get_character_by_cqi(cqi))
+        while pt_value > diff do
+            unit_to_remove = units_to_remove[cm:random_number(#units_to_remove)]
+            unit_to_remove_key = unit_to_remove:unit_key()
+            pt_value = rm:get_weight_for_unit(unit_to_remove_key, rm:get_character_by_cqi(cqi))
+        end
+        -- get the force's value pre-removal
+        local prior_value = cm:force_gold_value(force_cqi)
+        -- remove it
+        cm:remove_unit_from_character(cm:char_lookup_str(cqi), unit_to_remove_key)
+        diff = diff - pt_value
+        rm:log("removed unit ["..unit_to_remove_key.."] for ["..pt_value.."] points!")
+
+        -- pick a random default unit
                 local default_units = rm:ai_subculture_defaults()[character:faction():subculture()]
-                local new_unit = default_units[cm:random_number(#default_units)]
-                cm:grant_unit_to_character(cm:char_lookup_str(cqi), new_unit)
-                rm:log("removed unit ["..unit.."] and granted ["..new_unit.."] as a replacement unit!")
-                if rm:get_weight_for_unit(unit, rm:get_character_by_cqi(cqi)) >= diff then
+        local unit_to_add_idx = cm:random_number(#default_units)
+        local unit_to_add = default_units[unit_to_add_idx]
+        local tries = 1
+        while not force:can_recruit_unit(unit_to_add) and tries < #default_units do
+            -- retry
+            unit_to_add_idx = (unit_to_add_idx % #default_units) + 1
+            unit_to_add = default_units[unit_to_add_idx]
+            tries = tries + 1
+        end
+
+        -- stop here if there's no default unit recruitable selected
+        if unit_to_add == nil then
+            rm:log("couldn't recruit any randomly selected core unit!")
+        else
+            -- add the selected default unit
+            cm:grant_unit_to_character(cm:char_lookup_str(cqi), unit_to_add)
+            rm:log("granted ["..unit_to_add.."] as a replacement unit")
+        end
+        -- refund reasury the lost gold value of the force
+        local refund = prior_value - cm:force_gold_value(force_cqi)
+        cm:treasury_mod(character:faction():name(), refund)
+        rm:log("refunded "..refund.." for lost value")
+
+        if diff > 0 then
+            rm:log("removed unit was insufficient, repeating with diff of ["..diff.."]!")
+        elseif diff < 0 then
+            rm:log("removed unit was too much?! ERROR! diff of ["..diff.."]")
+        else
                     rm:log("removed unit was sufficient!")
-                    return
                 end
-                diff = diff - rm:get_weight_for_unit(unit, rm:get_character_by_cqi(cqi));
-                rm:log("removed unit was insufficient, repeating!")
             end
         end
     end

--- a/script/campaign/mod/AICharacterRecruitmentControls.lua
+++ b/script/campaign/mod/AICharacterRecruitmentControls.lua
@@ -134,6 +134,7 @@ local function rm_ai_recruitment(character, recruited_unit)
                         -- add the selected default unit
                         cm:grant_unit_to_character(cm:char_lookup_str(cqi), unit_to_add)
                         rm:log("granted ["..unit_to_add.."] as a replacement core unit")
+                        local character_faction = character:faction():name()
                         core:add_listener(
                             "rm_granted_unit_to_ai_force",
                             "UnitCreated",
@@ -142,7 +143,7 @@ local function rm_ai_recruitment(character, recruited_unit)
                             end,
                             function(context)
                                 local unit_cost = context:unit():get_unit_custom_battle_cost()
-                                cm:treasury_mod(character:faction():name(), -unit_cost)
+                                cm:treasury_mod(character_faction, -unit_cost)
                                 rm:log("charged ["..unit_cost.."]g for replacement unit ["..context:unit():unit_key().."]")
                             end,
                             false)
@@ -150,7 +151,7 @@ local function rm_ai_recruitment(character, recruited_unit)
                             "rm_granted_unit_to_ai_force_gc",
                             "FactionTurnEnd",
                             function(context)
-                                return context:faction():name() == character:faction():name()
+                                return context:faction():name() == character_faction
                             end,
                             function(context)
                                 rm:log("ending listening for unit creation for ["..context:faction():name().."]")

--- a/script/campaign/mod/AICharacterRecruitmentControls.lua
+++ b/script/campaign/mod/AICharacterRecruitmentControls.lua
@@ -110,6 +110,11 @@ local function rm_ai_recruitment(character, recruited_unit)
                     cm:remove_unit_from_character(cm:char_lookup_str(cqi), unit_to_remove_key)
                     rm:log("removed recruited unit ["..unit_to_remove_key.."] costing ["..rm:get_weight_for_unit(unit_to_remove_key, rm:get_character_by_cqi(cqi)).."] points!")
 
+                    -- refund treasury the gold value of the the removed unit
+                    local refund = recruited_unit:get_unit_custom_battle_cost()
+                    cm:treasury_mod(character:faction():name(), refund)
+                    rm:log("refunded ["..refund.."]g for lost value")
+
                     -- pick a random default unit
                     local default_units = rm:ai_subculture_defaults()[character:faction():subculture()]
                     local unit_to_add_idx = cm:random_number(#default_units)
@@ -153,11 +158,6 @@ local function rm_ai_recruitment(character, recruited_unit)
                             end,
                             false)
                     end
-                    -- refund treasury the gold value of the the removed unit
-                    local refund = recruited_unit:get_unit_custom_battle_cost()
-                    cm:treasury_mod(character:faction():name(), refund)
-                    rm:log("refunded ["..refund.."]g for lost value")
-
                     break
                 end
             end


### PR DESCRIPTION
Modified, added, changed, and removed various features in script/campaign/mod/AICharacterRecruitmentControls.lua to address several issues:

- AI was being refunded full value for removed units, but getting the replacement units for free
- Lizardmen were being refunded almost all the units they'd get from the rite that spawns a stack of dinos (updated to allow the overloaded dino stack)
- Legendary Lord starting armies were having their bonus units removed in some cases
- Some AI default forces lists had some repeats and/or typos
- Replacement units didn't check to ensure that faction was capable of recruiting that unit into that force
- Chaos Invasions could have their armies severely neutrered (now allows overloaded invasion forces to keep their units)

This also allows only checking each force that does recruitment, rather than checking every ai force every turn by using the UnitRecruited event, rather than just looping every force at the beginning of the AI turn.

This addresses https://github.com/DrunkFlamingo/RecruitmentManager/issues/3